### PR TITLE
By default mock `fetch` requests in specs, preventing accidental dependency on an external service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^15.14.0",
         "jest": "^29.7.0",
+        "jest-fetch-mock": "^3.0.3",
         "prettier": "^3.4.2",
         "prisma": "^6.3.1",
         "source-map-support": "^0.5.21",
@@ -5194,6 +5195,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7687,6 +7698,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -8876,6 +8898,27 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9498,6 +9541,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prompts": {
@@ -10957,6 +11007,13 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -11464,6 +11521,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack": {
       "version": "5.97.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
@@ -11576,6 +11640,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^15.14.0",
     "jest": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^3.4.2",
     "prisma": "^6.3.1",
     "source-map-support": "^0.5.21",
@@ -74,6 +75,7 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "setupFilesAfterEnv": ["<rootDir>/jest/jest.setup.ts"],
     "testEnvironment": "node"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CatsController } from './cats/cats.controller';
 import { RoutesModule } from './commands/routes.module';
+import { FetcherService } from './fetcher/fetcher.service';
 
 @Module({
   imports: [
@@ -11,6 +12,6 @@ import { RoutesModule } from './commands/routes.module';
     RoutesModule
   ],
   controllers: [AppController, CatsController],
-  providers: [AppService],
+  providers: [AppService, FetcherService],
 })
 export class AppModule {}

--- a/src/fetcher/fetcher.service.spec.ts
+++ b/src/fetcher/fetcher.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FetcherService } from './fetcher.service';
+
+describe('FetcherService', () => {
+  let service: FetcherService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FetcherService],
+    }).compile();
+
+    service = module.get<FetcherService>(FetcherService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should have a method', () => {
+    expect(service.getNarf).toBeDefined();
+  });
+
+  it('should do a silly thing', async () => {
+    const answer = await service.getNarf('unused');
+    expect(answer).toBe('narf');
+  });
+
+  it('should have a fetching method', () => {
+    expect(service.getCat).toBeDefined();
+  });
+
+  it('should fetch the cat', async () => {    
+    let url = 'https://http.cat/201';
+    let response = await service.getCat();
+    expect(response.status).toBe(200);
+  }
+  );
+});

--- a/src/fetcher/fetcher.service.spec.ts
+++ b/src/fetcher/fetcher.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FetcherService } from './fetcher.service';
+import fetchMock from "jest-fetch-mock";
 
 describe('FetcherService', () => {
   let service: FetcherService;
@@ -36,6 +37,16 @@ describe('FetcherService', () => {
 
     expect(response.status).toBe(200);
     expect(body).toBe('');  
-  }
-  );
+  });
+
+  it('allows disabling the mock', async () => {
+    fetchMock.disableMocks();
+
+    let response = await service.getCat('nope');
+    let body = await response.text();
+
+    // This is not a real page, so should 404, with some html or something
+    expect(response.status).toBe(404);
+    expect(body.length).toBeGreaterThan(10);
+  });
 });

--- a/src/fetcher/fetcher.service.spec.ts
+++ b/src/fetcher/fetcher.service.spec.ts
@@ -31,8 +31,11 @@ describe('FetcherService', () => {
 
   it('should fetch the cat', async () => {    
     let url = 'https://http.cat/201';
-    let response = await service.getCat();
+    let response = await service.getCat('nope');
+    let body = await response.text();
+
     expect(response.status).toBe(200);
+    expect(body).toBe('');  
   }
   );
 });

--- a/src/fetcher/fetcher.service.spec.ts
+++ b/src/fetcher/fetcher.service.spec.ts
@@ -30,13 +30,34 @@ describe('FetcherService', () => {
     expect(service.getCat).toBeDefined();
   });
 
-  it('should fetch the cat', async () => {    
+  it('should empty 200 by default', async () => {    
     let url = 'https://http.cat/201';
     let response = await service.getCat('nope');
     let body = await response.text();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/plain;charset=UTF-8');
     expect(body).toBe('');  
+  });
+
+  it('allows mocking fetch', async () => {
+    fetchMock.mockResponseOnce('mocked response');
+    let response = await service.getCat('nope');
+    let body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/plain;charset=UTF-8');
+    expect(body).toBe('mocked response');  
+  });
+
+  it('can mock status and headers', async () => {
+    fetchMock.mockResponseOnce('hi mom', { status: 204, headers: { 'x-something-fake': 'narf' } });
+    let response = await service.getCat('nope');
+    let body = await response.text();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('x-something-fake')).toBe('narf');
+    expect(body).toBe('hi mom');  
   });
 
   it('allows disabling the mock', async () => {

--- a/src/fetcher/fetcher.service.ts
+++ b/src/fetcher/fetcher.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FetcherService {
+  async getNarf(arg: String) {
+    return 'narf';
+  }
+
+  async getCat() {
+    let url = 'https://http.cat/201';
+    let response = await fetch(url);
+    return response;
+  }
+}

--- a/src/fetcher/fetcher.service.ts
+++ b/src/fetcher/fetcher.service.ts
@@ -6,8 +6,9 @@ export class FetcherService {
     return 'narf';
   }
 
-  async getCat() {
-    let url = 'https://http.cat/201';
+  async getCat(cat: String) : Promise<Response> {
+    // let url = 'https://http.cat/201';
+    let url = 'https://http.cat/' + cat;
     let response = await fetch(url);
     return response;
   }

--- a/src/jest/jest.setup.ts
+++ b/src/jest/jest.setup.ts
@@ -1,0 +1,3 @@
+// jest.setup.ts
+import 'jest-fetch-mock/setupJest';
+require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
By default `fetch` will make real web requests.

To use this in test is at best to risk test fragility, in the common case likely to add time to your test runs, and in the worst case might annoy the operators of the service you're depending on.

This change causes our tests to default to using a mocked service, and demonstrates how to add mock responses to test your code, and how to add an exclusion for those cases where you really do want to make an external call.  (Don't do this!)