### PR TITLE
Run tests in a database transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "setupFilesAfterEnv": ["<rootDir>/jest/jest.prisma.setup.ts"],
     "testEnvironment": "node"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,13 +4,16 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CatsController } from './cats/cats.controller';
 import { RoutesModule } from './commands/routes.module';
+import { UserService } from './user/user.service';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
+    PrismaModule,
     RoutesModule
   ],
   controllers: [AppController, CatsController],
-  providers: [AppService],
+  providers: [AppService, UserService],
 })
 export class AppModule {}

--- a/src/jest/jest.prisma.setup.ts
+++ b/src/jest/jest.prisma.setup.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { AppModule } from '../app.module';
+import { getTestModule } from './shared-test.module';
+
+let prismaService: PrismaService;
+
+beforeAll(async () => {
+  const moduleFixture = await getTestModule();
+  prismaService = moduleFixture.get<PrismaService>(PrismaService);
+});
+
+beforeEach(async () => {
+  await prismaService.$executeRaw`BEGIN`;
+});
+
+afterEach(async () => {
+  await prismaService.$executeRaw`ROLLBACK`;
+});

--- a/src/jest/shared-test.module.ts
+++ b/src/jest/shared-test.module.ts
@@ -1,0 +1,13 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../app.module';
+
+let testModule: TestingModule;
+
+export async function getTestModule() {
+  if (!testModule) {
+    testModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  }
+  return testModule;
+} 

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {} 

--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,15 @@
+import { PrismaService } from './prisma.service';
+import { getTestModule } from '../jest/shared-test.module';
+
+describe('PrismaService', () => {
+  let service: PrismaService;
+
+  beforeEach(async () => {
+    const module = await getTestModule();
+    service = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient { }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,20 @@
+import { UserService } from './user.service';
+import { getTestModule } from '../jest/shared-test.module';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module = await getTestModule();
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should create a user', async () => {
+    const user = await service.makeUser("Bob Dobbs", "bob@example.net");
+    expect(user.id).toBeDefined();
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class UserService {
+  constructor(private prisma: PrismaService) {}
+
+  async makeUser(name: string, email: string) : Promise<User> {
+    const user = {
+      name: name,
+      email: email
+    }
+    const newUser = await this.prisma.user.create({ data: { name: name, email: email } })
+    return newUser;
+  }
+}


### PR DESCRIPTION
(Arguably this would tell a better story with multiple commits that build on each other.)

First, add a UserService and a spec demonstrating its use.

The test will fail if run twice, because the first run will leave a record in the test database that the second run will conflict with.

Second, add the infrastructure to run jest tests in a database transaction.